### PR TITLE
Add PUMA: Semantic-Preserving Early Exit for Reasoning Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Below is a taxonomy graph summarizing the current landscape of efficient reasoni
 * Entropy After `</Think>` for reasoning model early exiting [[Paper]](https://arxiv.org/abs/2509.26522)  ![](https://img.shields.io/badge/pdf-2025.09-red) (.)
 * Parallel-R1: Towards Parallel Thinking via Reinforcement Learning. [[Paper]](https://arxiv.org/abs/2509.07980) ![](https://img.shields.io/badge/pdf-2025.09-red) (.)
 * DTS: Enhancing Large Reasoning Models via Decoding Tree Sketching [[Paper]](https://arxiv.org/pdf/2511.00640) [[Code]](https://github.com/ZichengXu/Decoding-Tree-Sketching) [[Colab]](https://colab.research.google.com/github/ZichengXu/Decoding-Tree-Sketching/blob/main/notebooks/example_DeepSeek_R1_Distill_Qwen_1_5B.ipynb) ![](https://img.shields.io/badge/pdf-2026.02-red)
+* Stop When Reasoning Converges: Semantic-Preserving Early Exit for Reasoning Models [[Paper]](https://arxiv.org/abs/2605.17672) [[Code]](https://github.com/giovanni-vaccarino/PUMA) ![](https://img.shields.io/badge/pdf-2026.05-red)
 
 ## Section V: Prompt-Guided Efficient Reasoning
 


### PR DESCRIPTION
Adding **PUMA** (arXiv 2026-05) to **Section IV: Dynamic Reasoning Paradigm during Inference** — directly relevant to the section's scope alongside FlashThink, ThinkLess, TrimR, Stop Spinning Wheels, "Entropy After \`</Think>\`", and DTS.

PUMA is a plug-and-play inference-time early-exit framework for Large Reasoning Models. Existing inference-time early-exit methods (like FlashThink, ThinkLess, Stop Spinning Wheels) rely on answer-level signals — confidence or trial-answer consistency — which may trigger before the model has finished exploring or self-correcting. PUMA introduces **reasoning-level semantic redundancy** as a complementary signal: a lightweight Redundancy Detector (fine-tuned Qwen3-Embedding-0.6B with a contrastive objective) flags candidate exits when recent reasoning steps stop adding novel semantic progress; an Answer Verification window then confirms whether stopping is safe.

Results across 5 LRMs (DeepSeek-R1-Distill-Qwen-7B/14B/32B, Llama-3.1-Nemotron-Nano-8B, Qwen3-30B-A3B-Thinking) and 5 reasoning benchmarks (MATH-500, AIME24, AIME25, OlympiadBench, GPQA-Diamond): **26.2% average token reduction** with preserved (slightly improved) accuracy; 1.40× / 1.28× wall-clock speedup on DS-7B/14B. Also generalizes to LiveCodeBench (code) and zero-shot VLM reasoning (MathVista, MathVision).

- Paper: https://arxiv.org/abs/2605.17672
- Code:  https://github.com/giovanni-vaccarino/PUMA

Thanks for maintaining this list — it's the canonical reference for this area.